### PR TITLE
Fix Netlify build: npm install over npm ci, redirect to 200.html

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,13 @@
 [build]
-  command = "npm run build"
+  # Use npm install (not npm ci) so Netlify tolerates the react-snap entry
+  # in package.json that isn't yet in package-lock.json (install failed
+  # locally due to no Chromium network access in the sandbox).
+  command = "npm install && npm run build"
   publish = "build"
   functions = "functions"
   [build.environment]
     CI = "false"
+    # Allow puppeteer (react-snap dependency) to download Chromium on Netlify.
     PUPPETEER_SKIP_DOWNLOAD = "false"
 
 [dev]
@@ -20,10 +24,13 @@
   status = 200
   force = true
 
-# SPA fallback — use 404 so pre-rendered route snapshots (react-snap) are
-# served directly by Netlify's CDN before this rule is evaluated.
-# A 200 rewrite here would override every pre-rendered index.html.
+# SPA fallback for react-snap.
+# react-snap writes pre-rendered index.html into each route folder AND
+# creates build/200.html as the pure SPA shell fallback.
+# Netlify serves the pre-rendered file when it exists (files take priority
+# over non-forced redirect rules), then falls back to 200.html for any
+# route that wasn't pre-rendered.
 [[redirects]]
   from = "/*"
-  to = "/index.html"
-  status = 404
+  to = "/200.html"
+  status = 200


### PR DESCRIPTION
## Two issues blocking the Netlify deploy

### 1. `npm ci` fails — package-lock.json missing react-snap

`react-snap` was added to `package.json` devDependencies but local install failed (no access to `storage.googleapis.com` for the Chromium binary). So `package-lock.json` has no entry for it. Netlify's default `npm ci` exits immediately with a lock-file mismatch error.

**Fix:** Build command changed to `npm install && npm run build` — Netlify resolves and installs react-snap fresh, downloads Chromium, then runs the build + postbuild.

### 2. SPA fallback pointed to wrong file

react-snap creates `build/200.html` as the SPA shell fallback (distinct from `index.html` which is the pre-rendered home page). The redirect was pointing to `/index.html` with `status = 404`.

**Fix:** Redirect changed to `/200.html` with `status = 200`. Netlify serves pre-rendered files when they exist (files take priority over non-forced redirect rules), falls back to `200.html` for any route not pre-rendered.

## After this deploy verify with
```bash
curl -sL https://asikhfarms.in | grep -E "<title>|og:title|og:description"
ls build/200.html   # confirms react-snap ran
```

https://claude.ai/code/session_012vzJA4uUAdZcqgbMevavhb